### PR TITLE
Fixed undefined behaviour, removed redundancies, made the file linkable and compilable

### DIFF
--- a/Bit Manipulation/rotate/cpp/rotate-bits-of-n.cpp
+++ b/Bit Manipulation/rotate/cpp/rotate-bits-of-n.cpp
@@ -3,18 +3,18 @@
 #define INT_BITS 32
 
 int leftRotate(int n, unsigned int d){
-   return (n << d)|(n >> (INT_BITS - d));
+   return n << d%INT_BITS;
 }
 
 int rightRotate(int n, unsigned int d){
-   return (n >> d)|(n << (INT_BITS - d));
+   return n >> d%INT_BITS;
 }
 
 int main(){
   int n,d;
   //input n (number) and d (no. of bits)
-  cin>>n>>d;
-  cout<<"Left Rotation of "<<n<<" by "<<d<<" is "<<leftRotate(n,d) <<endl;
-  cout<<"Right Rotation of "<<n<<" by "<<d<<" is "<<rightRotate(n,d) <<endl
+  std::cin>>n>>d;
+  std::cout<<"Left Rotation of "<<n<<" by "<<d<<" is "<<leftRotate(n,d) <<std::endl;
+  std::cout<<"Right Rotation of "<<n<<" by "<<d<<" is "<<rightRotate(n,d) <<std::endl;
   return 0;
 }

--- a/Graphs/BinaryTree/c/binary.c
+++ b/Graphs/BinaryTree/c/binary.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <stdio.h>
+
 struct node 
 { 
 	int data; 
@@ -9,53 +12,58 @@ struct node
 right pointers. */
 struct node* newNode(int data) 
 { 
-// Allocate memory for new node 
-struct node* node = (struct node*)malloc(sizeof(struct node)); 
+	// Allocate memory for new node 
+	struct node* node = malloc(sizeof(struct node)); 
 
-// Assign data to this node 
-node->data = data; 
+	// Assign data to this node 
+	node->data = data; 
 
-// Initialize left and right children as NULL 
-node->left = NULL; 
-node->right = NULL; 
-return(node); 
+	// Initialize left and right children as NULL 
+	node->left = NULL; 
+	node->right = NULL; 
+	return(node); 
 } 
 
 
 int main() 
 { 
-/*create root*/
-struct node *root = newNode(1); 
-/* following is the tree after above statement 
+	/*create root*/
+	struct node *root = newNode(1); 
+	/* following is the tree after above statement 
 
-		1 
+			1 
+		/ \ 
+		NULL NULL 
+	*/
+
+
+	root->left	 = newNode(2); 
+	root->right	 = newNode(3); 
+	/* 2 and 3 become left and right children of 1 
+			1 
+			/ \ 
+			2	 3 
+		/ \ / \ 
+		NULL NULL NULL NULL 
+	*/
+
+
+	root->left->left = newNode(4); 
+	/* 4 becomes left child of 2 
+			1 
+		/	 \ 
+		2		 3 
+		/ \	 / \ 
+	4 NULL NULL NULL 
 	/ \ 
 	NULL NULL 
-*/
+	*/
 	
-
-root->left	 = newNode(2); 
-root->right	 = newNode(3); 
-/* 2 and 3 become left and right children of 1 
-		1 
-		/ \ 
-		2	 3 
-	/ \ / \ 
-	NULL NULL NULL NULL 
-*/
-
-
-root->left->left = newNode(4); 
-/* 4 becomes left child of 2 
-		1 
-	/	 \ 
-	2		 3 
-	/ \	 / \ 
-4 NULL NULL NULL 
-/ \ 
-NULL NULL 
-*/
-
-getchar(); 
-return 0; 
+	free(root->left->left);
+	free(root->left);
+	free(root->right);
+	free(root);
+	
+	getchar(); 
+	return 0; 
 }


### PR DESCRIPTION
The code exhibited three main issues which have been fixed in this commit:

1. non-standard, non-portable code and possible redundancies;
2. lines that result into compiling errors;
3. lines that result into linking errors.

1: in functions `leftRotate` and `rightRotate`, any instance of `d` with value bigger or equal than `INT_BITS` results into undefined behaviour according to any C++ standard. In particular, the following is a recurring part in every C++ standard:

> 1    [...] The operands shall be of integral or unscoped enumeration type and integral promotions are performed. The type of the result is that of the promoted left operand. The behavior is undefined if the right operand is negative, or **greater than or equal to the length in bits of the promoted left operand**.

Moreover, the solution can be derived from the next point:

> 2   The value of E1 << E2 is E1 left-shifted E2 bit positions; vacated bits are zero-filled. If E1 has an unsigned type, the value of the result is E1 × 2^E2, reduced modulo one more than the maximum value representable in the result type. Otherwise, **if E1 has a signed type and non-negative value**, and E1 × 2^E2 is representable in the **corresponding unsigned** type of the result type, then that value, _converted to the result type_, **is the resulting value**; otherwise, the behavior is undefined.

This clearly shows how _any_ value less or equal to 2^32-1, indipendently of the type being signed or not, can be generated - and stored in the final (possibly signed) type - as a result of a left shift operation. Thus, for `sizeof (int) == 4` and `int i = 1;`, then a left shift of `i`by 31 bits results in the corresponding unsigned type to have a representable value of 2^31, and for `i` (assuming a sign and module representation), ` i==-2147483648`, since its most significant bit is 1 and the rest is 0.
The standard also assures that the final stored value will be, provided that it can be represented in the unsigned type, _exactly_ E1 × 2^E2, thus there is no need to implement a rotational bit shift with `|(n >> (INT_BITS - d))`, since that functionality is already implemented in the left shift operator. The same can be said for the right shift operator, with the exception of the final value being the integral part of E1/2^E2.

Therefore, the only requirement in the code is to assure that our `d` value won't cause any undefined behavior, i.e., we must be sure that `d<INT_BITS`. One would expect that, assuming we want to obtain a rotational shift as in the original code, if a left/right shift equal to the size of the considered memory region is performed, then the result is still the same, i.e., `i<<32` should return the same literal as `i<<0`, that is, `i`. It is clear that from this periodic behavior we can conclude that `INT_BITS` is a module, and thus `d%INT_BITS` returns always the desired number of bits to be shifted, which is always less or equal to `INT_BITS-1`.


2: line 18 causes a compiling error because there is a missing `;` which was properly inserted.
3: every instance of standard identifiers causes the linker to throw an error because no name was specified for each identifier, nor are we within the `std` namespace. This was fixing by adding the `std::` prefix before each instance.

Edit: the code can still generate undefined behavior for negative values of `n` (in `leftRotate` and `rightRotate`), but that can be dealt with on a separate commit.
Also, the code is still not portable, since we are assuming a CPU arch that implements `int` as a 32 bit type. This can be fixed by either using a `int32_t` type or by using `CHAR_BIT*sizeof(int)` or `WORD_BIT` instead of the defined `INT_BITS`.
Finally, fortunately, the code should be endian-agnostic.